### PR TITLE
Rooms sort_order creation repositioning

### DIFF
--- a/db/migrate/20100207003248_create_rooms.rb
+++ b/db/migrate/20100207003248_create_rooms.rb
@@ -6,6 +6,7 @@ class CreateRooms < ActiveRecord::Migration
 
       t.text :string
       t.integer :capacity # what if capacity changes depending on layout?
+      t.integer :sort_order, :integer, { :default => 0 }
 
       t.timestamps
       t.column :lock_version, :integer, { :default => 0 }

--- a/db/migrate/20141104181518_add_sort_order_venue.rb
+++ b/db/migrate/20141104181518_add_sort_order_venue.rb
@@ -1,7 +1,6 @@
 class AddSortOrderVenue < ActiveRecord::Migration
   def change
     add_column :venues, :sort_order, :integer, { :default => 0 }
-    add_column :rooms, :sort_order, :integer, { :default => 0 }
     add_column :published_venues, :sort_order, :integer, { :default => 0 }
     add_column :published_rooms, :sort_order, :integer, { :default => 0 }
   end


### PR DESCRIPTION
I've repositioned the creation of the sort_order field in rooms to avoid errors during the migrations run.

The error was caused while running the script in `20110426113730_link_room_setups.rb`.
